### PR TITLE
Refactor Phod and Schema classes to integrate MessageProvider

### DIFF
--- a/src/Message/MessageProvider.php
+++ b/src/Message/MessageProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Rei\Phod\Message;
+
+interface MessageProvider
+{
+    public function get(string $key): string;
+
+    /**
+     * get the message
+     *
+     * @param array<int, string> $params
+     */
+    public function message(string $key, array $params = []): string;
+
+    /**
+     * get the message with replaced params
+     *
+     * @param array<int, string> $params
+     */
+    public function replace(string $message, array $params = []): string;
+}

--- a/src/ParseContext.php
+++ b/src/ParseContext.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Rei\Phod;
+
+readonly class ParseContext
+{
+    public function __construct(
+        public string $key,
+    )
+    {
+        //
+    }
+}

--- a/src/ParseResult.php
+++ b/src/ParseResult.php
@@ -10,12 +10,12 @@ final readonly class ParseResult
     /**
      * @param bool $succeed
      * @param T $value
-     * @param string $message
+     * @param string|null $message
      */
     public function __construct(
         public bool $succeed,
         public mixed $value,
-        public string $message = '',
+        public ?string $message = null,
     )
     {
         //

--- a/src/Phod.php
+++ b/src/Phod.php
@@ -7,58 +7,71 @@ use Rei\Phod\Schema\BoolSchema;
 use Rei\Phod\Schema\ArraySchema;
 use Rei\Phod\Schema\FloatSchema;
 use Rei\Phod\Schema\StringSchema;
+use Rei\Phod\Message\MessageProvider;
 
 
 class Phod
 {
     /**
+     * @param MessageProvider $messageProvider
+     */
+    public function __construct(protected MessageProvider $messageProvider) {
+        //
+    }
+
+    /**
      * Make a StringSchema.
      *
+     * @param array{invalid_type_message?: string, required_message?: string} $options
      * @return StringSchema
      */
-    public function string(): StringSchema
+    public function string(array $options = []): StringSchema
     {
-        return new StringSchema();
+        return new StringSchema($this->messageProvider, $options);
     }
 
     /**
      * Make an IntSchema.
      *
+     * @param array{invalid_type_message?: string, required_message?: string} $options
      * @return IntSchema
      */
-    public function int(): IntSchema
+    public function int(array $options = []): IntSchema
     {
-        return new IntSchema();
+        return new IntSchema($this->messageProvider, $options);
     }
 
     /**
      * Make a FloatSchema.
      *
+     * @param array{invalid_type_message?: string, required_message?: string} $options
      * @return FloatSchema
      */
-    public function float(): FloatSchema
+    public function float(array $options = []): FloatSchema
     {
-        return new FloatSchema();
+        return new FloatSchema($this->messageProvider, $options);
     }
 
     /**
      * Make a BoolSchema.
      *
+     * @param array{invalid_type_message?: string, required_message?: string} $options
      * @return BoolSchema
      */
-    public function bool(): BoolSchema
+    public function bool(array $options = []): BoolSchema
     {
-        return new BoolSchema();
+        return new BoolSchema($this->messageProvider, $options);
     }
 
     /**
      * Make an ArraySchema.
      *
-     * @param array<string, PhodSchema> $data
+     * @param array<int, mixed> $data
+     * @param array{invalid_type_message?: string, required_message?: string} $options
      * @return ArraySchema
      */
-    public function array(array $data): ArraySchema
+    public function array(array $data = [], array $options = []): ArraySchema
     {
-        return new ArraySchema($data);
+        return new ArraySchema($this->messageProvider, $data, $options);
     }
 }

--- a/src/Schema/ArraySchema.php
+++ b/src/Schema/ArraySchema.php
@@ -3,6 +3,9 @@
 namespace Rei\Phod\Schema;
 
 use Rei\Phod\PhodSchema;
+use Rei\Phod\ParseResult;
+use Rei\Phod\ParseContext;
+use Rei\Phod\Message\MessageProvider;
 
 /**
  * @extends \Rei\Phod\PhodSchema<array>
@@ -12,35 +15,69 @@ class ArraySchema extends PhodSchema
     /**
      * construct the schema
      *
+     * @param MessageProvider $messageProvider
      * @param array<string, PhodSchema> $schemas
-     * @param string $message
+     * @param array{invalid_type_message?: string, required_message?: string} $options
      */
-    public function __construct(array $schemas, string $message = 'Value must be an array')
-    {
-        $valueValidators = array_merge(...array_map(
-            fn($schema, $key) => $this->makeValueValidators($key, $schema),
-            $schemas,
-            array_keys($schemas),
-        ));
+    public function __construct(
+        MessageProvider $messageProvider,
+        array $schemas,
+        array $options = [],
+    ) {
+        parent::__construct($messageProvider);
 
-        parent::__construct([
-            fn($value, $failed) => is_array($value) ?: $failed($message),
-            ...$valueValidators,
-        ]);
+        $message = $options['invalid_type_message'] ?? $this->messageProvider->get('invalid_type');
+
+        $this->isArray($message)->isValidSchema($schemas);
     }
 
     /**
-     * make the value validators
+     * Rule to check if the value is an array.
      *
-     * @param string $key
-     * @param PhodSchema $schema
-     * @return array<int, \Closure>
+     * @param string $message
+     * @return static
      */
-    private function makeValueValidators(string $key, PhodSchema $schema): array
+    private function isArray(string $message): static
     {
-        return array_map(
-            fn($validator) => (fn($value, $failed) => $validator($value[$key] ?? null, $failed)),
-            $schema->validators(),
-        );
+        $this->validators[] = function(mixed $value, ParseContext $context) use ($message) {
+            if (is_array($value)) {
+                return new ParseResult(true, $value);
+            }
+
+            return new ParseResult(
+                false,
+                $value,
+                $this->messageProvider->replace($message, ['key' => $context->key]),
+            );
+        };
+
+        return $this;
+    }
+
+    /**
+     * Rule to check if the value is valid schema.
+     *
+     * @param array<string, PhodSchema> $schemas
+     * @return static
+     */
+    private function isValidSchema(array $schemas): static
+    {
+        $this->validators[] = function(mixed $value, ParseContext $context) use ($schemas) {
+            foreach ($value as $key => $item) {
+                $schema = $schemas[$key] ?? null;
+
+                if ($schema) {
+                    $result = $schema->safeParse($item, new ParseContext($key));
+
+                    if (!$result->succeed) {
+                        return $result;
+                    }
+                }
+            }
+
+            return new ParseResult(true, $value);
+        };
+
+        return $this;
     }
 }

--- a/src/Schema/BoolSchema.php
+++ b/src/Schema/BoolSchema.php
@@ -3,6 +3,9 @@
 namespace Rei\Phod\Schema;
 
 use Rei\Phod\PhodSchema;
+use Rei\Phod\ParseResult;
+use Rei\Phod\ParseContext;
+use Rei\Phod\Message\MessageProvider;
 
 /**
  * @extends \Rei\Phod\PhodSchema<bool>
@@ -12,12 +15,40 @@ class BoolSchema extends PhodSchema
     /**
      * construct the schema
      *
-     * @param string $message
+     * @param MessageProvider $messageProvider
+     * @param array{invalid_type_message?: string, required_message?: string} $options
      */
-    public function __construct(string $message = 'Value must be a boolean')
+    public function __construct(
+        MessageProvider $messageProvider,
+        array $options = [],
+    ) {
+        parent::__construct($messageProvider);
+
+        $this->isBool(isset($options['invalid_type_message']) ? ['message' => $options['invalid_type_message']] : []);
+    }
+
+    /**
+     * Rule to check if the value is a boolean.
+     *
+     * @param array{message?: string} $options
+     * @return static
+     */
+    private function isBool(array $options = []): static
     {
-        parent::__construct([
-            fn($value, $failed) => is_bool($value) ?: $failed($message),
-        ]);
+        $message = $options['message'] ?? $this->messageProvider->get('invalid_type');
+
+        $this->validators[] = function(mixed $value, ParseContext $context) use ($message) {
+            if (is_bool($value)) {
+                return new ParseResult(true, $value);
+            }
+
+            return new ParseResult(
+                false,
+                $value,
+                $this->messageProvider->replace($message, ['key' => $context->key]),
+            );
+        };
+
+        return $this;
     }
 }

--- a/src/Schema/FloatSchema.php
+++ b/src/Schema/FloatSchema.php
@@ -3,6 +3,9 @@
 namespace Rei\Phod\Schema;
 
 use Rei\Phod\PhodSchema;
+use Rei\Phod\ParseResult;
+use Rei\Phod\ParseContext;
+use Rei\Phod\Message\MessageProvider;
 
 /**
  * @extends \Rei\Phod\PhodSchema<float>
@@ -12,12 +15,40 @@ class FloatSchema extends PhodSchema
     /**
      * construct the schema
      *
-     * @param string $message
+     * @param MessageProvider $messageProvider
+     * @param array{invalid_type_message?: string, required_message?: string} $options
      */
-    public function __construct(string $message = 'Value must be a float')
+    public function __construct(
+        MessageProvider $messageProvider,
+        array $options = [],
+    ) {
+        parent::__construct($messageProvider);
+
+        $this->isFloat(isset($options['invalid_type_message']) ? ['message' => $options['invalid_type_message']] : []);
+    }
+
+    /**
+     * Rule to check if the value is a float.
+     *
+     * @param array{message?: string} $options
+     * @return static
+     */
+    private function isFloat(array $options = []): static
     {
-        parent::__construct([
-            fn($value, $failed) => is_float($value) ?: $failed($message),
-        ]);
+        $message = $options['message'] ?? $this->messageProvider->get('invalid_type');
+
+        $this->validators[] = function(mixed $value, ParseContext $context) use ($message) {
+            if (is_float($value)) {
+                return new ParseResult(true, $value);
+            }
+
+            return new ParseResult(
+                false,
+                $value,
+                $this->messageProvider->replace($message, ['key' => $context->key]),
+            );
+        };
+
+        return $this;
     }
 }

--- a/src/Schema/IntSchema.php
+++ b/src/Schema/IntSchema.php
@@ -3,18 +3,52 @@
 namespace Rei\Phod\Schema;
 
 use Rei\Phod\PhodSchema;
+use Rei\Phod\ParseResult;
+use Rei\Phod\ParseContext;
+use Rei\Phod\Message\MessageProvider;
 
+/**
+ * @extends \Rei\Phod\PhodSchema<int>
+ */
 class IntSchema extends PhodSchema
 {
     /**
      * construct the schema
      *
-     * @param string $message
+     * @param MessageProvider $messageProvider
+     * @param array{invalid_type_message?: string, required_message?: string} $options
      */
-    public function __construct(string $message = 'Value must be an integer')
+    public function __construct(
+        MessageProvider $messageProvider,
+        array $options = [],
+    ) {
+        parent::__construct($messageProvider);
+
+        $this->isInt(isset($options['invalid_type_message']) ? ['message' => $options['invalid_type_message']] : []);
+    }
+
+    /**
+     * Rule to check if the value is an integer.
+     *
+     * @param array{message?: string} $options
+     * @return static
+     */
+    private function isInt(array $options = []): static
     {
-        parent::__construct([
-            fn($value, $failed) => is_int($value) ?: $failed($message),
-        ]);
+        $message = $options['message'] ?? $this->messageProvider->get('invalid_type');
+
+        $this->validators[] = function(mixed $value, ParseContext $context) use ($message) {
+            if (is_int($value)) {
+                return new ParseResult(true, $value);
+            }
+
+            return new ParseResult(
+                false,
+                $value,
+                $this->messageProvider->replace($message, ['key' => $context->key]),
+            );
+        };
+
+        return $this;
     }
 }

--- a/src/Schema/StringSchema.php
+++ b/src/Schema/StringSchema.php
@@ -3,6 +3,9 @@
 namespace Rei\Phod\Schema;
 
 use Rei\Phod\PhodSchema;
+use Rei\Phod\ParseResult;
+use Rei\Phod\ParseContext;
+use Rei\Phod\Message\MessageProvider;
 
 /**
  * @extends \Rei\Phod\PhodSchema<string>
@@ -12,12 +15,40 @@ class StringSchema extends PhodSchema
     /**
      * construct the schema
      *
-     * @param string $message
+     * @param MessageProvider $messageProvider
+     * @param array{invalid_type_message?: string, required_message?: string} $options
      */
-    public function __construct(string $message = 'Value must be a string')
+    public function __construct(
+        MessageProvider $messageProvider,
+        array $options = [],
+    ) {
+        parent::__construct($messageProvider);
+
+        $this->isString(isset($options['invalid_type_message']) ? ['message' => $options['invalid_type_message']] : []);
+    }
+
+    /**
+     * Rule to check if the value is a string.
+     *
+     * @param array{message?: string} $options
+     * @return static
+     */
+    private function isString(array $options = []): static
     {
-        parent::__construct([
-            fn($value, $failed) => is_string($value) ?: $failed($message),
-        ]);
+        $message = $options['message'] ?? $this->messageProvider->get('invalid_type');
+
+        $this->validators[] = function(mixed $value, ParseContext $context) use ($message) {
+            if (is_string($value)) {
+                return new ParseResult(true, $value);
+            }
+
+            return new ParseResult(
+                false,
+                $value,
+                $this->messageProvider->replace($message, ['key' => $context->key]),
+            );
+        };
+
+        return $this;
     }
 }

--- a/tests/Unit/PhodTest.php
+++ b/tests/Unit/PhodTest.php
@@ -7,10 +7,30 @@ use Rei\Phod\Schema\BoolSchema;
 use Rei\Phod\Schema\ArraySchema;
 use Rei\Phod\Schema\FloatSchema;
 use Rei\Phod\Schema\StringSchema;
+use Rei\Phod\Message\MessageProvider;
+
+beforeEach(function () {
+    $this->messageProvider = new class implements MessageProvider {
+        public function get(string $key): string
+        {
+            return 'Value must be an integer';
+        }
+
+        public function message(string $key, array $params = []): string
+        {
+            return 'Value must be an integer';
+        }
+
+        public function replace(string $message, array $params = []): string
+        {
+            return str_replace(array_keys($params), array_values($params), $message);
+        }
+    };
+});
 
 describe('string method', function () {
     it('should return a string schema', function () {
-        $phod = new Phod();
+        $phod = new Phod($this->messageProvider);
         $schema = $phod->string();
         expect($schema)
             ->toBeInstanceOf(PhodSchema::class)
@@ -20,7 +40,7 @@ describe('string method', function () {
 
 describe('int method', function () {
     it('should return an int schema', function () {
-        $phod = new Phod();
+        $phod = new Phod($this->messageProvider);
         $schema = $phod->int();
         expect($schema)
             ->toBeInstanceOf(PhodSchema::class)
@@ -30,7 +50,7 @@ describe('int method', function () {
 
 describe('float method', function () {
     it('should return a float schema', function () {
-        $phod = new Phod();
+        $phod = new Phod($this->messageProvider);
         $schema = $phod->float();
         expect($schema)
             ->toBeInstanceOf(PhodSchema::class)
@@ -40,7 +60,7 @@ describe('float method', function () {
 
 describe('bool method', function () {
     it('should return a bool schema', function () {
-        $phod = new Phod();
+        $phod = new Phod($this->messageProvider);
         $schema = $phod->bool();
         expect($schema)
             ->toBeInstanceOf(PhodSchema::class)
@@ -50,7 +70,7 @@ describe('bool method', function () {
 
 describe('array method', function () {
     it('should return an array schema', function () {
-        $phod = new Phod();
+        $phod = new Phod($this->messageProvider);
         $schema = $phod->array([]);
         expect($schema)
             ->toBeInstanceOf(PhodSchema::class)

--- a/tests/Unit/Schema/ArraySchemaTest.php
+++ b/tests/Unit/Schema/ArraySchemaTest.php
@@ -1,20 +1,40 @@
 <?php
 
+use Rei\Phod\Schema\IntSchema;
 use Rei\Phod\Schema\ArraySchema;
 use Rei\Phod\Schema\StringSchema;
-use Rei\Phod\Schema\IntSchema;
+use Rei\Phod\Message\MessageProvider;
 use Rei\Phod\PhodParseFailedException;
+
+beforeEach(function () {
+    $this->messageProvider = new class implements MessageProvider {
+        public function get(string $key): string
+        {
+            return 'Value must be an array';
+        }
+
+        public function message(string $key, array $params = []): string
+        {
+            return 'Value must be an array';
+        }
+
+        public function replace(string $message, array $params = []): string
+        {
+            return str_replace(array_keys($params), array_values($params), $message);
+        }
+    };
+});
 
 describe('parse method', function () {
     it('should throw an exception if any validator returns false', function () {
-        $schema = new ArraySchema([]);
+        $schema = new ArraySchema($this->messageProvider, []);
         expect(fn() => $schema->parse('string'))->toThrow(PhodParseFailedException::class, 'Value must be an array');
     });
 
     it('should return the value if all validators return true', function () {
-        $schema = new ArraySchema([
-            'name' => new StringSchema(),
-            'age' => new IntSchema(),
+        $schema = new ArraySchema($this->messageProvider, [
+            'name' => new StringSchema($this->messageProvider),
+            'age' => new IntSchema($this->messageProvider),
         ]);
         $result = $schema->parse([
             'name' => 'John',
@@ -29,13 +49,13 @@ describe('parse method', function () {
 
 describe('safeParse method', function () {
     it('should return a PaseResult object', function () {
-        $schema = new ArraySchema([]);
+        $schema = new ArraySchema($this->messageProvider, []);
         $result = $schema->safeParse([]);
         expect($result->succeed)->toBeTrue();
     });
 
     it('should return a PaseResult object with the correct message if the value is not an array', function () {
-        $schema = new ArraySchema([]);
+        $schema = new ArraySchema($this->messageProvider, []);
         $result = $schema->safeParse('string');
         expect($result->succeed)->toBeFalse();
         expect($result->message)->toBe('Value must be an array');

--- a/tests/Unit/Schema/BoolSchemaTest.php
+++ b/tests/Unit/Schema/BoolSchemaTest.php
@@ -1,32 +1,52 @@
 <?php
 
 use Rei\Phod\Schema\BoolSchema;
+use Rei\Phod\Message\MessageProvider;
 use Rei\Phod\PhodParseFailedException;
+
+beforeEach(function () {
+    $this->messageProvider = new class implements MessageProvider {
+        public function get(string $key): string
+        {
+            return 'Value must be a boolean';
+        }
+
+        public function message(string $key, array $params = []): string
+        {
+            return 'Value must be a boolean';
+        }
+
+        public function replace(string $message, array $params = []): string
+        {
+            return str_replace(array_keys($params), array_values($params), $message);
+        }
+    };
+});
 
 describe('parse method', function () {
     it('should return the value if all validators return true', function () {
-        $schema = new BoolSchema();
+        $schema = new BoolSchema($this->messageProvider);
         $result = $schema->parse(true);
 
         expect($result)->toBeTrue();
     });
 
     it('should throw an exception if any validator returns false', function () {
-        $schema = new BoolSchema();
+        $schema = new BoolSchema($this->messageProvider);
         expect(fn() => $schema->parse('string'))->toThrow(PhodParseFailedException::class, 'Value must be a boolean');
     });
 });
 
 describe('safeParse method', function () {
-    it('should return a PaseResult object', function () {
-        $schema = new BoolSchema();
+    it('should return a ParseResult object', function () {
+        $schema = new BoolSchema($this->messageProvider);
         $result = $schema->safeParse(true);
 
         expect($result->succeed)->toBeTrue();
     });
 
-    it('should return a PaseResult object with the correct message if the value is not a boolean', function () {
-        $schema = new BoolSchema();
+    it('should return a ParseResult object with the correct message if the value is not a boolean', function () {
+        $schema = new BoolSchema($this->messageProvider);
         $result = $schema->safeParse('string');
 
         expect($result->succeed)->toBeFalse();

--- a/tests/Unit/Schema/FloatSchemaTest.php
+++ b/tests/Unit/Schema/FloatSchemaTest.php
@@ -1,32 +1,52 @@
 <?php
 
 use Rei\Phod\Schema\FloatSchema;
+use Rei\Phod\Message\MessageProvider;
 use Rei\Phod\PhodParseFailedException;
+
+beforeEach(function () {
+    $this->messageProvider = new class implements MessageProvider {
+        public function get(string $key): string
+        {
+            return 'Value must be a float';
+        }
+
+        public function message(string $key, array $params = []): string
+        {
+            return 'Value must be a float';
+        }
+
+        public function replace(string $message, array $params = []): string
+        {
+            return str_replace(array_keys($params), array_values($params), $message);
+        }
+    };
+});
 
 describe('parse method', function () {
     it('should return the value if all validators return true', function () {
-        $schema = new FloatSchema();
+        $schema = new FloatSchema($this->messageProvider);
         $result = $schema->parse(1.23);
 
         expect($result)->toBe(1.23);
     });
 
     it('should throw an exception if any validator returns false', function () {
-        $schema = new FloatSchema();
+        $schema = new FloatSchema($this->messageProvider);
         expect(fn() => $schema->parse('string'))->toThrow(PhodParseFailedException::class, 'Value must be a float');
     });
 });
 
 describe('safeParse method', function () {
-    it('should return a PaseResult object', function () {
-        $schema = new FloatSchema();
+    it('should return a ParseResult object', function () {
+        $schema = new FloatSchema($this->messageProvider);
         $result = $schema->safeParse(1.23);
 
         expect($result->succeed)->toBeTrue();
     });
 
-    it('should return a PaseResult object with the correct message if the value is not a float', function () {
-        $schema = new FloatSchema();
+    it('should return a ParseResult object with the correct message if the value is not a float', function () {
+        $schema = new FloatSchema($this->messageProvider);
         $result = $schema->safeParse('string');
 
         expect($result->succeed)->toBeFalse();

--- a/tests/Unit/Schema/IntSchemaTest.php
+++ b/tests/Unit/Schema/IntSchemaTest.php
@@ -1,30 +1,50 @@
 <?php
 
 use Rei\Phod\Schema\IntSchema;
+use Rei\Phod\Message\MessageProvider;
 use Rei\Phod\PhodParseFailedException;
+
+beforeEach(function () {
+    $this->messageProvider = new class implements MessageProvider {
+        public function get(string $key): string
+        {
+            return 'Value must be an integer';
+        }
+
+        public function message(string $key, array $params = []): string
+        {
+            return 'Value must be an integer';
+        }
+
+        public function replace(string $message, array $params = []): string
+        {
+            return str_replace(array_keys($params), array_values($params), $message);
+        }
+    };
+});
 
 describe('parse method', function () {
     it('should return the value if all validators return true', function () {
-        $schema = new IntSchema();
+        $schema = new IntSchema($this->messageProvider);
         $result = $schema->parse(123);
         expect($result)->toBe(123);
     });
 
     it('should throw an exception if any validator returns false', function () {
-        $schema = new IntSchema();
+        $schema = new IntSchema($this->messageProvider);
         expect(fn() => $schema->parse('value'))->toThrow(PhodParseFailedException::class, 'Value must be an integer');
     });
 });
 
 describe('safeParse method', function () {
     it('should return a PaseResult object', function () {
-        $schema = new IntSchema();
+        $schema = new IntSchema($this->messageProvider);
         $result = $schema->safeParse(123);
         expect($result->succeed)->toBeTrue();
     });
 
     it('should return a PaseResult object with the correct message if the value is not an integer', function () {
-        $schema = new IntSchema();
+        $schema = new IntSchema($this->messageProvider);
         $result = $schema->safeParse('value');
         expect($result->succeed)->toBeFalse();
         expect($result->message)->toBe('Value must be an integer');

--- a/tests/Unit/Schema/StringSchemaTest.php
+++ b/tests/Unit/Schema/StringSchemaTest.php
@@ -1,32 +1,52 @@
 <?php
 
 use Rei\Phod\Schema\StringSchema;
+use Rei\Phod\Message\MessageProvider;
 use Rei\Phod\PhodParseFailedException;
+
+beforeEach(function () {
+    $this->messageProvider = new class implements MessageProvider {
+        public function get(string $key): string
+        {
+            return 'Value must be a string';
+        }
+
+        public function message(string $key, array $params = []): string
+        {
+            return 'Value must be a string';
+        }
+
+        public function replace(string $message, array $params = []): string
+        {
+            return strtr($message, array_map(fn($key) => ":$key", array_keys($params)));
+        }
+    };
+});
 
 describe('parse method', function () {
     it('should return the value if all validators return true', function () {
-        $schema = new StringSchema();
+        $schema = new StringSchema($this->messageProvider);
         $result = $schema->parse('value');
 
         expect($result)->toBe('value');
     });
 
     it('should throw an exception if any validator returns false', function () {
-        $schema = new StringSchema();
+        $schema = new StringSchema($this->messageProvider);
         expect(fn() => $schema->parse(123))->toThrow(PhodParseFailedException::class, 'Value must be a string');
     });
 });
 
 describe('safeParse method', function () {
     it('should return a PaseResult object', function () {
-        $schema = new StringSchema();
+        $schema = new StringSchema($this->messageProvider);
         $result = $schema->safeParse('value');
 
         expect($result->succeed)->toBeTrue();
     });
 
     it('should return a PaseResult object with the correct message if the value is not a string', function () {
-        $schema = new StringSchema();
+        $schema = new StringSchema($this->messageProvider);
         $result = $schema->safeParse(123);
 
         expect($result->succeed)->toBeFalse();


### PR DESCRIPTION
- Updated constructors of Phod and schema classes (StringSchema, IntSchema, FloatSchema, BoolSchema, ArraySchema) to accept MessageProvider and options for custom error messages.
- Modified the parse and safeParse methods to utilize the new structure for error handling.
- Enhanced tests to ensure compatibility with the new MessageProvider integration.
- Updated the ParseResult class to allow nullable messages.