### PR TITLE
機能追加: 型キャスト機能の実装とテストの追加

### DIFF
--- a/src/PhodSchema.php
+++ b/src/PhodSchema.php
@@ -69,6 +69,7 @@ class PhodSchema
      */
     protected function safeParseWithContext(mixed $value, ParseContext $context): ParseResult
     {
+        $value = $this->cast($value);
         foreach ($this->validators as $validator) {
             $result = $validator($value, $context);
 
@@ -102,5 +103,16 @@ class PhodSchema
     protected function message(string $message, array $replaces = []): string
     {
         return strtr($message, array_map(fn($key) => ":$key", array_keys($replaces)));
+    }
+
+    /**
+     * cast the value
+     *
+     * @param mixed $value
+     * @return T
+     */
+    protected function cast(mixed $value): mixed
+    {
+        return $value;
     }
 }

--- a/src/Schema/AssociativeArraySchema.php
+++ b/src/Schema/AssociativeArraySchema.php
@@ -32,6 +32,18 @@ class AssociativeArraySchema extends PhodSchema
     }
 
     /**
+     * @inheritDoc
+    */
+    protected function cast(mixed $value): mixed
+    {
+        if (is_scalar($value) || is_null($value)) {
+            return $value;
+        }
+
+        return (array) $value;
+    }
+
+    /**
      * Rule to check if the value is an array.
      *
      * @param string $message

--- a/src/Schema/BoolSchema.php
+++ b/src/Schema/BoolSchema.php
@@ -28,6 +28,20 @@ class BoolSchema extends PhodSchema
     }
 
     /**
+     * @inheritDoc
+     */
+    protected function cast(mixed $value): mixed
+    {
+        $casted = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        if ($casted === null) {
+            return $value;
+        }
+
+        return $casted;
+    }
+
+    /**
      * Rule to check if the value is a boolean.
      *
      * @param array{message?: string} $options

--- a/src/Schema/FloatSchema.php
+++ b/src/Schema/FloatSchema.php
@@ -28,6 +28,18 @@ class FloatSchema extends PhodSchema
     }
 
     /**
+     * @inheritDoc
+     */
+    protected function cast(mixed $value): mixed
+    {
+        if (is_numeric($value)) {
+            return (float) $value;
+        }
+
+        return $value;
+    }
+
+    /**
      * Rule to check if the value is a float.
      *
      * @param array{message?: string} $options

--- a/src/Schema/IntSchema.php
+++ b/src/Schema/IntSchema.php
@@ -28,6 +28,25 @@ class IntSchema extends PhodSchema
     }
 
     /**
+     * @inheritDoc
+     */
+    protected function cast(mixed $value): mixed
+    {
+        if (is_numeric($value)) {
+            $intCasted = (int) $value;
+            $floatCasted = (float) $value;
+
+            if ($intCasted == $floatCasted) {
+                return $intCasted;
+            } else {
+                return $floatCasted;
+            }
+        }
+
+        return $value;
+    }
+
+    /**
      * Rule to check if the value is an integer.
      *
      * @param array{message?: string} $options

--- a/src/Schema/StringSchema.php
+++ b/src/Schema/StringSchema.php
@@ -28,6 +28,18 @@ class StringSchema extends PhodSchema
     }
 
     /**
+     * @inheritDoc
+     */
+    protected function cast(mixed $value): mixed
+    {
+        if (is_null($value) || is_object($value) && !($value instanceof \Stringable)) {
+            return $value;
+        }
+
+        return (string) $value;
+    }
+
+    /**
      * Rule to check if the value is a string.
      *
      * @param array{message?: string} $options

--- a/tests/Unit/Schema/AssociativeArraySchemaTest.php
+++ b/tests/Unit/Schema/AssociativeArraySchemaTest.php
@@ -45,6 +45,23 @@ describe('parse method', function () {
             'age' => 30,
         ]);
     });
+
+    it('should cast the value to an array', function () {
+        $schema = new AssociativeArraySchema($this->messageProvider, [
+            'name' => new StringSchema($this->messageProvider),
+            'age' => new IntSchema($this->messageProvider),
+        ]);
+
+        $data = new stdClass();
+        $data->name = 'John';
+        $data->age = 30;
+
+        $result = $schema->parse($data);
+        expect($result)->toBe([
+            'name' => 'John',
+            'age' => 30,
+        ]);
+    });
 });
 
 describe('safeParse method', function () {
@@ -59,5 +76,23 @@ describe('safeParse method', function () {
         $result = $schema->safeParse('string');
         expect($result->succeed)->toBeFalse();
         expect($result->message)->toBe('Value must be an array');
+    });
+
+    it('should cast the value to an array', function () {
+        $schema = new AssociativeArraySchema($this->messageProvider, [
+            'name' => new StringSchema($this->messageProvider),
+            'age' => new IntSchema($this->messageProvider),
+        ]);
+
+        $data = new stdClass();
+        $data->name = 'John';
+        $data->age = 30;
+
+        $result = $schema->safeParse($data);
+        expect($result->succeed)->toBeTrue();
+        expect($result->value)->toBe([
+            'name' => 'John',
+            'age' => 30,
+        ]);
     });
 });

--- a/tests/Unit/Schema/BoolSchemaTest.php
+++ b/tests/Unit/Schema/BoolSchemaTest.php
@@ -35,6 +35,12 @@ describe('parse method', function () {
         $schema = new BoolSchema($this->messageProvider);
         expect(fn() => $schema->parse('string'))->toThrow(PhodParseFailedException::class, 'Value must be a boolean');
     });
+
+    it('should cast the value to a boolean', function () {
+        $schema = new BoolSchema($this->messageProvider);
+        expect($schema->parse(1))->toBeTrue();
+        expect($schema->parse(0))->toBeFalse();
+    });
 });
 
 describe('safeParse method', function () {
@@ -51,5 +57,16 @@ describe('safeParse method', function () {
 
         expect($result->succeed)->toBeFalse();
         expect($result->message)->toBe('Value must be a boolean');
+    });
+
+    it('should cast the value to a boolean', function () {
+        $schema = new BoolSchema($this->messageProvider);
+        $result = $schema->safeParse(1);
+        expect($result->succeed)->toBeTrue();
+        expect($result->value)->toBeTrue();
+
+        $result = $schema->safeParse(0);
+        expect($result->succeed)->toBeTrue();
+        expect($result->value)->toBeFalse();
     });
 });

--- a/tests/Unit/Schema/FloatSchemaTest.php
+++ b/tests/Unit/Schema/FloatSchemaTest.php
@@ -35,6 +35,13 @@ describe('parse method', function () {
         $schema = new FloatSchema($this->messageProvider);
         expect(fn() => $schema->parse('string'))->toThrow(PhodParseFailedException::class, 'Value must be a float');
     });
+
+    it('should cast the value to a float', function () {
+        $schema = new FloatSchema($this->messageProvider);
+        $result = $schema->parse('1.23');
+
+        expect($result)->toBe(1.23);
+    });
 });
 
 describe('safeParse method', function () {
@@ -52,8 +59,26 @@ describe('safeParse method', function () {
         expect($result->succeed)->toBeFalse();
         expect($result->message)->toBe('Value must be a float');
 
-        $result = $schema->safeParse(123);
+        $result = $schema->safeParse(new stdClass());
         expect($result->succeed)->toBeFalse();
         expect($result->message)->toBe('Value must be a float');
+    });
+
+    it('should cast the value to a float', function () {
+        $schema = new FloatSchema($this->messageProvider);
+        $result = $schema->safeParse('1.23');
+
+        expect($result->succeed)->toBeTrue();
+        expect($result->value)->toBe(1.23);
+
+        $result = $schema->safeParse(2);
+        expect($result->succeed)->toBeTrue();
+        expect($result->value)->toBe(2.0);
+
+        $result = $schema->safeParse(null);
+        expect($result->value)->toBeNull();
+
+        $result = $schema->safeParse(new stdClass());
+        expect($result->value)->toBeInstanceOf(stdClass::class);
     });
 });

--- a/tests/Unit/Schema/IntSchemaTest.php
+++ b/tests/Unit/Schema/IntSchemaTest.php
@@ -33,6 +33,12 @@ describe('parse method', function () {
     it('should throw an exception if any validator returns false', function () {
         $schema = new IntSchema($this->messageProvider);
         expect(fn() => $schema->parse('value'))->toThrow(PhodParseFailedException::class, 'Value must be an integer');
+        expect(fn() => $schema->parse(2.2))->toThrow(PhodParseFailedException::class, 'Value must be an integer');
+    });
+
+    it('should cast the value to an integer', function () {
+        $schema = new IntSchema($this->messageProvider);
+        expect($schema->parse('123'))->toBe(123);
     });
 });
 
@@ -48,5 +54,22 @@ describe('safeParse method', function () {
         $result = $schema->safeParse('value');
         expect($result->succeed)->toBeFalse();
         expect($result->message)->toBe('Value must be an integer');
+    });
+
+    it('should cast the value to an integer', function () {
+        $schema = new IntSchema($this->messageProvider);
+        $result = $schema->safeParse('123');
+        expect($result->succeed)->toBeTrue();
+        expect($result->value)->toBe(123);
+
+        $result = $schema->safeParse(2.2);
+        expect($result->succeed)->toBeFalse();
+        expect($result->value)->toBe(2.2);
+
+        $result = $schema->safeParse(null);
+        expect($result->value)->toBeNull();
+
+        $result = $schema->safeParse(new stdClass());
+        expect($result->value)->toBeInstanceOf(stdClass::class);
     });
 });

--- a/tests/Unit/Schema/StringSchemaTest.php
+++ b/tests/Unit/Schema/StringSchemaTest.php
@@ -33,7 +33,12 @@ describe('parse method', function () {
 
     it('should throw an exception if any validator returns false', function () {
         $schema = new StringSchema($this->messageProvider);
-        expect(fn() => $schema->parse(123))->toThrow(PhodParseFailedException::class, 'Value must be a string');
+        expect(fn() => $schema->parse(new stdClass()))->toThrow(PhodParseFailedException::class, 'Value must be a string');
+    });
+
+    it('should cast the value to a string', function () {
+        $schema = new StringSchema($this->messageProvider);
+        expect($schema->parse(123))->toBe('123');
     });
 });
 
@@ -47,9 +52,21 @@ describe('safeParse method', function () {
 
     it('should return a PaseResult object with the correct message if the value is not a string', function () {
         $schema = new StringSchema($this->messageProvider);
-        $result = $schema->safeParse(123);
+        $result = $schema->safeParse(new stdClass());
 
         expect($result->succeed)->toBeFalse();
         expect($result->message)->toBe('Value must be a string');
+    });
+
+    it('should cast the value to a string', function () {
+        $schema = new StringSchema($this->messageProvider);
+        $result = $schema->safeParse(123);
+        expect($result->value)->toBe('123');
+
+        $result = $schema->safeParse(null);
+        expect($result->value)->toBeNull();
+
+        $result = $schema->safeParse(new stdClass());
+        expect($result->value)->toBeInstanceOf(stdClass::class);
     });
 });


### PR DESCRIPTION
- PhodSchemaクラスに型キャストメソッドを追加し、各スキーマクラスでオーバーライド。
- BoolSchema、FloatSchema、IntSchema、StringSchema、AssociativeArraySchemaにおいて、適切な型キャストを実装。
- 各スキーマのテストケースを追加し、型キャストの動作を確認。
- テストの整合性を保つために、既存のテストケースも修正。
- ArraySchemaはキャストする意味がない（キーが文字列になる or スカラーが配列になる）のでキャストしない