### PR TITLE
機能追加: スキーマのリファイン機能の実装

### DIFF
--- a/src/PhodSchema.php
+++ b/src/PhodSchema.php
@@ -146,6 +146,19 @@ class PhodSchema
     }
 
     /**
+     * refine the schema
+     *
+     * @param callable(mixed, ParseContext): ParseResult<T> $validator
+     * @return static
+     */
+    public function refine(callable $validator): static
+    {
+        $this->validators[] = $validator;
+
+        return $this;
+    }
+
+    /**
      * get the message
      *
      * @param array<int, string> $replaces

--- a/tests/Unit/PhodSchemaTest.php
+++ b/tests/Unit/PhodSchemaTest.php
@@ -139,3 +139,18 @@ describe('nullable method', function () {
         expect($result->value)->toBe('value');
     });
 });
+
+describe('refine method', function () {
+    it('should add any validator to the schema', function () {
+        $schema = new PhodSchema($this->messageProvider, []);
+
+        $schema->refine(function (mixed $value, ParseContext $context): ParseResult {
+            return new ParseResult(false, $value, 'refine');
+        });
+
+        $result = $schema->safeParse('value');
+
+        expect($result->succeed)->toBeFalse();
+        expect($result->message)->toBe('refine');
+    });
+});


### PR DESCRIPTION
- PhodSchemaクラスにリファインメソッドを追加し、カスタムバリデータをスキーマに追加できるようにしました。
- リファインメソッドは、引数として受け取ったバリデータを内部のバリデータ配列に追加します。
- 新しいリファインメソッドの動作を確認するためのテストケースを追加しました。