### PR TITLE
修正: エラーハンドリングと型の整合性の向上

### DIFF
--- a/src/ParseContext.php
+++ b/src/ParseContext.php
@@ -5,6 +5,7 @@ namespace Rei\Phod;
 readonly class ParseContext
 {
     public function __construct(
+        public array $path,
         public string $key,
     )
     {

--- a/src/ParseResult.php
+++ b/src/ParseResult.php
@@ -8,14 +8,14 @@ namespace Rei\Phod;
 final readonly class ParseResult
 {
     /**
-     * @param bool $succeed
+     * @param bool $success
      * @param T $value
-     * @param string|null $message
+     * @param PhodParseFailedException|null $exception
      */
     public function __construct(
-        public bool $succeed,
+        public bool $success,
         public mixed $value,
-        public ?string $message = null,
+        public ?PhodParseFailedException $exception = null,
     )
     {
         //

--- a/src/PhodParseFailedException.php
+++ b/src/PhodParseFailedException.php
@@ -4,5 +4,9 @@ namespace Rei\Phod;
 
 class PhodParseFailedException extends \Exception
 {
-    //
+    public function __construct(
+        readonly public PhodParseIssue $issue,
+    ) {
+        parent::__construct($issue->message);
+    }
 }

--- a/src/PhodParseIssue.php
+++ b/src/PhodParseIssue.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rei\Phod;
+
+readonly class PhodParseIssue
+{
+    /**
+     * construct the issue
+     *
+     * @param string $code
+     * @param (int|string)[] $path
+     * @param string $message
+     * @param array<string, mixed> $properties
+     */
+    public function __construct(
+        public string $code,
+        public array $path,
+        public string $message,
+        public array $properties = [],
+    ) {
+        //
+    }
+}

--- a/src/PhodSchema.php
+++ b/src/PhodSchema.php
@@ -15,9 +15,9 @@ class PhodSchema
     private const UNSET = '__UNSET__';
 
     /**
-     * @var string
+     * @var string|null
      */
-    protected string $key = 'the value';
+    protected ?string $key = null;
 
     /**
      * @var bool
@@ -52,8 +52,8 @@ class PhodSchema
     {
         $result = $this->safeParse($value);
 
-        if (!$result->succeed) {
-            throw new PhodParseFailedException($result->message);
+        if (!$result->success) {
+            throw $result->exception;
         }
 
         return $result->value;
@@ -67,7 +67,7 @@ class PhodSchema
      */
     public function safeParse(mixed $value): ParseResult
     {
-        $context = new ParseContext($this->key);
+        $context = new ParseContext([], $this->key ?? 'the value');
 
         return $this->safeParseWithContext($value, $context);
     }
@@ -90,7 +90,7 @@ class PhodSchema
         foreach ($this->validators as $validator) {
             $result = $validator($value, $context);
 
-            if (!$result->succeed) {
+            if (!$result->success) {
                 return $result;
             }
         }
@@ -109,6 +109,16 @@ class PhodSchema
         $this->key = $key;
 
         return $this;
+    }
+
+    /**
+     * get the key
+     *
+     * @return string|null
+     */
+    public function getKey(): ?string
+    {
+        return $this->key;
     }
 
     /**

--- a/src/Schema/BoolSchema.php
+++ b/src/Schema/BoolSchema.php
@@ -5,7 +5,9 @@ namespace Rei\Phod\Schema;
 use Rei\Phod\PhodSchema;
 use Rei\Phod\ParseResult;
 use Rei\Phod\ParseContext;
+use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Message\MessageProvider;
+use Rei\Phod\PhodParseFailedException;
 
 /**
  * @extends \Rei\Phod\PhodSchema<bool>
@@ -59,7 +61,13 @@ class BoolSchema extends PhodSchema
             return new ParseResult(
                 false,
                 $value,
-                $this->messageProvider->replace($message, ['key' => $context->key, 'type' => 'boolean']),
+                new PhodParseFailedException(
+                    new PhodParseIssue(
+                        'invalid_type',
+                        $context->path,
+                        $this->messageProvider->replace($message, ['key' => $context->key, 'type' => 'boolean']),
+                    ),
+                ),
             );
         };
 

--- a/src/Schema/FloatSchema.php
+++ b/src/Schema/FloatSchema.php
@@ -5,7 +5,9 @@ namespace Rei\Phod\Schema;
 use Rei\Phod\PhodSchema;
 use Rei\Phod\ParseResult;
 use Rei\Phod\ParseContext;
+use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Message\MessageProvider;
+use Rei\Phod\PhodParseFailedException;
 
 /**
  * @extends \Rei\Phod\PhodSchema<float>
@@ -57,7 +59,13 @@ class FloatSchema extends PhodSchema
             return new ParseResult(
                 false,
                 $value,
-                $this->messageProvider->replace($message, ['key' => $context->key, 'type' => 'float']),
+                new PhodParseFailedException(
+                    new PhodParseIssue(
+                        'invalid_type',
+                        $context->path,
+                        $this->messageProvider->replace($message, ['key' => $context->key, 'type' => 'float']),
+                    ),
+                ),
             );
         };
 

--- a/src/Schema/IntSchema.php
+++ b/src/Schema/IntSchema.php
@@ -5,7 +5,9 @@ namespace Rei\Phod\Schema;
 use Rei\Phod\PhodSchema;
 use Rei\Phod\ParseResult;
 use Rei\Phod\ParseContext;
+use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Message\MessageProvider;
+use Rei\Phod\PhodParseFailedException;
 
 /**
  * @extends \Rei\Phod\PhodSchema<int>
@@ -64,7 +66,13 @@ class IntSchema extends PhodSchema
             return new ParseResult(
                 false,
                 $value,
-                $this->messageProvider->replace($message, ['key' => $context->key, 'type' => 'integer']),
+                new PhodParseFailedException(
+                    new PhodParseIssue(
+                        'invalid_type',
+                        $context->path,
+                        $this->messageProvider->replace($message, ['key' => $context->key, 'type' => 'integer']),
+                    ),
+                ),
             );
         };
 

--- a/src/Schema/StringSchema.php
+++ b/src/Schema/StringSchema.php
@@ -5,7 +5,9 @@ namespace Rei\Phod\Schema;
 use Rei\Phod\PhodSchema;
 use Rei\Phod\ParseResult;
 use Rei\Phod\ParseContext;
+use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Message\MessageProvider;
+use Rei\Phod\PhodParseFailedException;
 
 /**
  * @extends \Rei\Phod\PhodSchema<string>
@@ -57,7 +59,13 @@ class StringSchema extends PhodSchema
             return new ParseResult(
                 false,
                 $value,
-                $this->messageProvider->replace($message, ['key' => $context->key, 'type' => 'string']),
+                new PhodParseFailedException(
+                    new PhodParseIssue(
+                        'invalid_type',
+                        $context->path,
+                        $this->messageProvider->replace($message, ['key' => $context->key, 'type' => 'string']),
+                    ),
+                ),
             );
         };
 

--- a/tests/Unit/PhodSchemaTest.php
+++ b/tests/Unit/PhodSchemaTest.php
@@ -3,6 +3,7 @@
 use Rei\Phod\PhodSchema;
 use Rei\Phod\ParseResult;
 use Rei\Phod\ParseContext;
+use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Message\MessageProvider;
 use Rei\Phod\PhodParseFailedException;
 
@@ -32,13 +33,33 @@ describe('parse method', function () {
                 if (is_string($value)) {
                     return new ParseResult(true, $value);
                 }
-                return new ParseResult(false, $value, 'Value must be a string');
+                return new ParseResult(
+                    false,
+                    $value,
+                    new PhodParseFailedException(
+                        new PhodParseIssue(
+                            'invalid_type',
+                            $context->path,
+                            'Value must be a string',
+                        ),
+                    ),
+                );
             },
             function (mixed $value, ParseContext $context): ParseResult {
                 if (strlen($value) >= 5) {
                     return new ParseResult(true, $value);
                 }
-                return new ParseResult(false, $value, 'String must be at least 5 characters long');
+                return new ParseResult(
+                    false,
+                    $value,
+                    new PhodParseFailedException(
+                        new PhodParseIssue(
+                            'invalid_type',
+                            $context->path,
+                            'String must be at least 5 characters long',
+                        ),
+                    ),
+                );
             },
         ]);
 
@@ -51,13 +72,33 @@ describe('parse method', function () {
                 if (is_string($value)) {
                     return new ParseResult(true, $value);
                 }
-                return new ParseResult(false, $value, 'Value must be a string');
+                return new ParseResult(
+                    false,
+                    $value,
+                    new PhodParseFailedException(
+                        new PhodParseIssue(
+                            'invalid_type',
+                            $context->path,
+                            'Value must be a string',
+                        ),
+                    ),
+                );
             },
             function (mixed $value, ParseContext $context): ParseResult {
                 if (strlen($value) >= 5) {
                     return new ParseResult(true, $value);
                 }
-                return new ParseResult(false, $value, 'String must be at least 5 characters long');
+                return new ParseResult(
+                    false,
+                    $value,
+                    new PhodParseFailedException(
+                        new PhodParseIssue(
+                            'invalid_type',
+                            $context->path,
+                            'String must be at least 5 characters long',
+                        ),
+                    ),
+                );
             },
         ]);
 
@@ -72,19 +113,39 @@ describe('safeParse method', function () {
                 if (is_string($value)) {
                     return new ParseResult(true, $value);
                 }
-                return new ParseResult(false, $value, 'Value must be a string');
+                return new ParseResult(
+                    false,
+                    $value,
+                    new PhodParseFailedException(
+                        new PhodParseIssue(
+                            'invalid_type',
+                            $context->path,
+                            'Value must be a string',
+                        ),
+                    ),
+                );
             },
             function (mixed $value, ParseContext $context): ParseResult {
                 if (strlen($value) >= 5) {
                     return new ParseResult(true, $value);
                 }
-                return new ParseResult(false, $value, 'String must be at least 5 characters long');
+                return new ParseResult(
+                    false,
+                    $value,
+                    new PhodParseFailedException(
+                        new PhodParseIssue(
+                            'invalid_type',
+                            $context->path,
+                            'String must be at least 5 characters long',
+                        ),
+                    ),
+                );
             },
         ]);
 
         $result = $schema->safeParse('value');
 
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
         expect($result->value)->toBe('value');
     });
 
@@ -94,21 +155,43 @@ describe('safeParse method', function () {
                 if (is_string($value)) {
                     return new ParseResult(true, $value);
                 }
-                return new ParseResult(false, $value, 'Value must be a string');
+                return new ParseResult(
+                    false,
+                    $value,
+                    new PhodParseFailedException(
+                        new PhodParseIssue(
+                            'invalid_type',
+                            $context->path,
+                            'Value must be a string',
+                        ),
+                    ),
+                );
             },
             function (mixed $value, ParseContext $context): ParseResult {
                 if (strlen($value) >= 5) {
                     return new ParseResult(true, $value);
                 }
-                return new ParseResult(false, $value, 'String must be at least 5 characters long');
+                return new ParseResult(
+                    false,
+                    $value,
+                    new PhodParseFailedException(
+                        new PhodParseIssue(
+                            'invalid_type',
+                            $context->path,
+                            'String must be at least 5 characters long',
+                        ),
+                    ),
+                );
             },
         ]);
 
         $result = $schema->safeParse('123');
 
-        expect($result->succeed)->toBeFalse();
+        expect($result->success)->toBeFalse();
         expect($result->value)->toBe('123');
-        expect($result->message)->toBe('String must be at least 5 characters long');
+        expect($result->exception)->toBeInstanceOf(PhodParseFailedException::class);
+        expect($result->exception->issue)->toBeInstanceOf(PhodParseIssue::class);
+        expect($result->exception->issue->message)->toBe('String must be at least 5 characters long');
     });
 });
 
@@ -116,26 +199,42 @@ describe('nullable method', function () {
     it('should return a ParseResult object if the value is nullable', function () {
         $schema = new PhodSchema($this->messageProvider, [
             function (mixed $value, ParseContext $context): ParseResult {
-                return new ParseResult(false, $value, 'Value must be a string');
+                return new ParseResult(false, $value,
+                    new PhodParseFailedException(
+                        new PhodParseIssue(
+                            'invalid_type',
+                            $context->path,
+                            'Value must be a string',
+                        ),
+                    ),
+                );
             },
         ]);
 
         $result = $schema->nullable()->safeParse(null);
 
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
         expect($result->value)->toBeNull();
     });
 
     it('should return a ParseResult object if the value is not nullable', function () {
         $schema = new PhodSchema($this->messageProvider, [
             function (mixed $value, ParseContext $context): ParseResult {
-                return new ParseResult(false, $value, 'Value must be a string');
+                return new ParseResult(false, $value,
+                    new PhodParseFailedException(
+                        new PhodParseIssue(
+                            'invalid_type',
+                            $context->path,
+                            'Value must be a string',
+                        ),
+                    ),
+                );
             },
         ]);
 
         $result = $schema->safeParse('value');
 
-        expect($result->succeed)->toBeFalse();
+        expect($result->success)->toBeFalse();
         expect($result->value)->toBe('value');
     });
 });
@@ -145,12 +244,22 @@ describe('refine method', function () {
         $schema = new PhodSchema($this->messageProvider, []);
 
         $schema->refine(function (mixed $value, ParseContext $context): ParseResult {
-            return new ParseResult(false, $value, 'refine');
+            return new ParseResult(false, $value,
+                new PhodParseFailedException(
+                    new PhodParseIssue(
+                        'invalid_type',
+                        $context->path,
+                        'refine',
+                    ),
+                ),
+            );
         });
 
         $result = $schema->safeParse('value');
 
-        expect($result->succeed)->toBeFalse();
-        expect($result->message)->toBe('refine');
+        expect($result->success)->toBeFalse();
+        expect($result->exception)->toBeInstanceOf(PhodParseFailedException::class);
+        expect($result->exception->issue)->toBeInstanceOf(PhodParseIssue::class);
+        expect($result->exception->issue->message)->toBe('refine');
     });
 });

--- a/tests/Unit/Schema/ArraySchemaTest.php
+++ b/tests/Unit/Schema/ArraySchemaTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Rei\Phod\ParseResult;
+use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Schema\ArraySchema;
 use Rei\Phod\Schema\StringSchema;
 use Rei\Phod\PhodParseFailedException;
@@ -27,14 +28,16 @@ describe('safeParse method', function () {
     it('should return a ParseResult with the value if all validators return true', function () {
         $schema = new ArraySchema($this->messageProvider, new StringSchema($this->messageProvider));
         $result = $schema->safeParse([]);
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
         expect($result->value)->toBe([]);
     });
 
     it('should return a ParseResult with the message if any validator returns false', function () {
         $schema = new ArraySchema($this->messageProvider, new StringSchema($this->messageProvider));
         $result = $schema->safeParse('string');
-        expect($result->succeed)->toBeFalse();
-        expect($result->message)->toBe('the value must be array');
+        expect($result->success)->toBeFalse();
+        expect($result->exception)->toBeInstanceOf(PhodParseFailedException::class);
+        expect($result->exception->issue)->toBeInstanceOf(PhodParseIssue::class);
+        expect($result->exception->issue->message)->toBe('the value must be array');
     });
 });

--- a/tests/Unit/Schema/AssociativeArraySchemaTest.php
+++ b/tests/Unit/Schema/AssociativeArraySchemaTest.php
@@ -1,9 +1,10 @@
 <?php
 
+use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Schema\IntSchema;
-use Rei\Phod\Schema\AssociativeArraySchema;
 use Rei\Phod\Schema\StringSchema;
 use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Schema\AssociativeArraySchema;
 
 describe('parse method', function () {
     it('should throw an exception if any validator returns false', function () {
@@ -48,18 +49,22 @@ describe('safeParse method', function () {
     it('should return a PaseResult object', function () {
         $schema = new AssociativeArraySchema($this->messageProvider, []);
         $result = $schema->safeParse([]);
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
     });
 
     it('should return a PaseResult object with the correct message if the value is not an array', function () {
         $schema = new AssociativeArraySchema($this->messageProvider, []);
         $result = $schema->safeParse('string');
-        expect($result->succeed)->toBeFalse();
-        expect($result->message)->toBe('the value must be array');
+        expect($result->success)->toBeFalse();
+        expect($result->exception)->toBeInstanceOf(PhodParseFailedException::class);
+        expect($result->exception->issue)->toBeInstanceOf(PhodParseIssue::class);
+        expect($result->exception->issue->message)->toBe('the value must be array');
 
         $result = $schema->safeParse(null);
-        expect($result->succeed)->toBeFalse();
-        expect($result->message)->toBe('the value must be array');
+        expect($result->success)->toBeFalse();
+        expect($result->exception)->toBeInstanceOf(PhodParseFailedException::class);
+        expect($result->exception->issue)->toBeInstanceOf(PhodParseIssue::class);
+        expect($result->exception->issue->message)->toBe('the value must be array');
     });
 
     it('should cast the value to an array', function () {
@@ -73,7 +78,7 @@ describe('safeParse method', function () {
         $data->age = 30;
 
         $result = $schema->safeParse($data);
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
         expect($result->value)->toBe([
             'name' => 'John',
             'age' => 30,
@@ -90,7 +95,7 @@ describe('safeParse method', function () {
             'name' => 'John',
             'age' => '30',
         ]);
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
         expect($result->value)->toBe([
             'name' => 'John',
             'age' => 30,
@@ -110,7 +115,7 @@ describe('optional method', function () {
             'name' => (new StringSchema($this->messageProvider))->optional(),
         ]);
         $result = $schema->safeParse([]);
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
         expect($result->value)->toBe([]);
     });
 
@@ -121,8 +126,10 @@ describe('optional method', function () {
         $result = $schema->safeParse([
             'age' => 30,
         ]);
-        expect($result->succeed)->toBeFalse();
-        expect($result->message)->toBe('the name is required');
+        expect($result->success)->toBeFalse();
+        expect($result->exception)->toBeInstanceOf(PhodParseFailedException::class);
+        expect($result->exception->issue)->toBeInstanceOf(PhodParseIssue::class);
+        expect($result->exception->issue->message)->toBe('the name is required');
     });
 });
 
@@ -134,7 +141,7 @@ describe('nullable method', function () {
         $result = $schema->safeParse([
             'name' => null,
         ]);
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
         expect($result->value)->toBe([
             'name' => null,
         ]);

--- a/tests/Unit/Schema/BoolSchemaTest.php
+++ b/tests/Unit/Schema/BoolSchemaTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Schema\BoolSchema;
 use Rei\Phod\PhodParseFailedException;
 
@@ -28,25 +29,27 @@ describe('safeParse method', function () {
         $schema = new BoolSchema($this->messageProvider);
         $result = $schema->safeParse(true);
 
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
     });
 
     it('should return a ParseResult object with the correct message if the value is not a boolean', function () {
         $schema = new BoolSchema($this->messageProvider);
         $result = $schema->safeParse('string');
 
-        expect($result->succeed)->toBeFalse();
-        expect($result->message)->toBe('the value must be boolean');
+        expect($result->success)->toBeFalse();
+        expect($result->exception)->toBeInstanceOf(PhodParseFailedException::class);
+        expect($result->exception->issue)->toBeInstanceOf(PhodParseIssue::class);
+        expect($result->exception->issue->message)->toBe('the value must be boolean');
     });
 
     it('should cast the value to a boolean', function () {
         $schema = new BoolSchema($this->messageProvider);
         $result = $schema->safeParse(1);
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
         expect($result->value)->toBeTrue();
 
         $result = $schema->safeParse(0);
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
         expect($result->value)->toBeFalse();
     });
 });

--- a/tests/Unit/Schema/FloatSchemaTest.php
+++ b/tests/Unit/Schema/FloatSchemaTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Schema\FloatSchema;
 use Rei\Phod\PhodParseFailedException;
 
@@ -30,30 +31,34 @@ describe('safeParse method', function () {
         $schema = new FloatSchema($this->messageProvider);
         $result = $schema->safeParse(1.23);
 
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
     });
 
     it('should return a ParseResult object with the correct message if the value is not a float', function () {
         $schema = new FloatSchema($this->messageProvider);
         $result = $schema->safeParse('string');
 
-        expect($result->succeed)->toBeFalse();
-        expect($result->message)->toBe('the value must be float');
+        expect($result->success)->toBeFalse();
+        expect($result->exception)->toBeInstanceOf(PhodParseFailedException::class);
+        expect($result->exception->issue)->toBeInstanceOf(PhodParseIssue::class);
+        expect($result->exception->issue->message)->toBe('the value must be float');
 
         $result = $schema->safeParse(new stdClass());
-        expect($result->succeed)->toBeFalse();
-        expect($result->message)->toBe('the value must be float');
+        expect($result->success)->toBeFalse();
+        expect($result->exception)->toBeInstanceOf(PhodParseFailedException::class);
+        expect($result->exception->issue)->toBeInstanceOf(PhodParseIssue::class);
+        expect($result->exception->issue->message)->toBe('the value must be float');
     });
 
     it('should cast the value to a float', function () {
         $schema = new FloatSchema($this->messageProvider);
         $result = $schema->safeParse('1.23');
 
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
         expect($result->value)->toBe(1.23);
 
         $result = $schema->safeParse(2);
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
         expect($result->value)->toBe(2.0);
 
         $result = $schema->safeParse(null);

--- a/tests/Unit/Schema/IntSchemaTest.php
+++ b/tests/Unit/Schema/IntSchemaTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Schema\IntSchema;
 use Rei\Phod\PhodParseFailedException;
 
@@ -27,24 +28,26 @@ describe('safeParse method', function () {
     it('should return a PaseResult object', function () {
         $schema = new IntSchema($this->messageProvider);
         $result = $schema->safeParse(123);
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
     });
 
     it('should return a PaseResult object with the correct message if the value is not an integer', function () {
         $schema = new IntSchema($this->messageProvider);
         $result = $schema->safeParse('value');
-        expect($result->succeed)->toBeFalse();
-        expect($result->message)->toBe('the value must be integer');
+        expect($result->success)->toBeFalse();
+        expect($result->exception)->toBeInstanceOf(PhodParseFailedException::class);
+        expect($result->exception->issue)->toBeInstanceOf(PhodParseIssue::class);
+        expect($result->exception->issue->message)->toBe('the value must be integer');
     });
 
     it('should cast the value to an integer', function () {
         $schema = new IntSchema($this->messageProvider);
         $result = $schema->safeParse('123');
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
         expect($result->value)->toBe(123);
 
         $result = $schema->safeParse(2.2);
-        expect($result->succeed)->toBeFalse();
+        expect($result->success)->toBeFalse();
         expect($result->value)->toBe(2.2);
 
         $result = $schema->safeParse(null);

--- a/tests/Unit/Schema/StringSchemaTest.php
+++ b/tests/Unit/Schema/StringSchemaTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Schema\StringSchema;
 use Rei\Phod\PhodParseFailedException;
 
@@ -28,15 +29,17 @@ describe('safeParse method', function () {
         $schema = new StringSchema($this->messageProvider);
         $result = $schema->safeParse('value');
 
-        expect($result->succeed)->toBeTrue();
+        expect($result->success)->toBeTrue();
     });
 
     it('should return a PaseResult object with the correct message if the value is not a string', function () {
         $schema = new StringSchema($this->messageProvider);
         $result = $schema->safeParse(new stdClass());
 
-        expect($result->succeed)->toBeFalse();
-        expect($result->message)->toBe('the value must be string');
+        expect($result->success)->toBeFalse();
+        expect($result->exception)->toBeInstanceOf(PhodParseFailedException::class);
+        expect($result->exception->issue)->toBeInstanceOf(PhodParseIssue::class);
+        expect($result->exception->issue->message)->toBe('the value must be string');
     });
 
     it('should cast the value to a string', function () {


### PR DESCRIPTION
- ParseResultクラスのプロパティ名を`succeed`から`success`に変更し、より明確な意味を持たせました。
- ParseResultのエラーメッセージを直接文字列からPhodParseFailedExceptionに変更し、エラー情報を構造化しました。
- ParseContextクラスに`path`プロパティを追加し、エラーメッセージにコンテキスト情報を含めるようにしました。
- 各スキーマクラス（ArraySchema、AssociativeArraySchema、BoolSchema、FloatSchema、IntSchema、StringSchema）でエラーメッセージを更新し、PhodParseFailedExceptionを使用するように修正しました。
- テストケースを更新し、エラーハンドリングの変更に対応しました。