### PR TITLE
機能追加: ParseContextの拡張メソッドの実装とエラーハンドリングの強化

### DIFF
--- a/src/ParseContext.php
+++ b/src/ParseContext.php
@@ -11,4 +11,17 @@ readonly class ParseContext
     {
         //
     }
+
+    /**
+     * extends the current context with a new path
+     *
+     * @param ParseContext $parent
+     * @param array $path
+     * @param string $key
+     * @return ParseContext
+     */
+    public static function extends(ParseContext $parent, array $path, string $key): ParseContext
+    {
+        return new ParseContext([...$parent->path, ...$path], $key);
+    }
 }

--- a/src/PhodSchema.php
+++ b/src/PhodSchema.php
@@ -4,7 +4,6 @@ namespace Rei\Phod;
 
 use Rei\Phod\ParseResult;
 use Rei\Phod\Message\MessageProvider;
-use Rei\Phod\PhodParseFailedException;
 
 
 /**
@@ -67,20 +66,22 @@ class PhodSchema
      */
     public function safeParse(mixed $value): ParseResult
     {
-        $context = new ParseContext([], $this->key ?? 'the value');
-
-        return $this->safeParseWithContext($value, $context);
+        return $this->safeParseWithContext($value, null);
     }
 
     /**
      * parse the value with context
      *
      * @param mixed $value
-     * @param ParseContext $context
+     * @param ParseContext|null $context
      * @return ParseResult<T>
      */
-    protected function safeParseWithContext(mixed $value, ParseContext $context): ParseResult
+    protected function safeParseWithContext(mixed $value, ?ParseContext $context): ParseResult
     {
+        $context = $context
+            ? ParseContext::extends($context, [], $this->key ?? $context->key)
+            : new ParseContext([], $this->key ?? 'the value');
+
         $value = $this->cast($value);
 
         if ($this->nullable && is_null($value)) {

--- a/tests/Unit/Schema/AssociativeArraySchemaTest.php
+++ b/tests/Unit/Schema/AssociativeArraySchemaTest.php
@@ -101,6 +101,19 @@ describe('safeParse method', function () {
             'age' => 30,
         ]);
     });
+
+    it('should return a ParseResult object with error if invalid value is passed', function () {
+        $schema = new AssociativeArraySchema($this->messageProvider, [
+            'name' => (new StringSchema($this->messageProvider))->key('名前'),
+        ]);
+        $result = $schema->safeParse([
+            'name' => new stdClass(),
+        ]);
+        expect($result->success)->toBeFalse();
+        expect($result->exception)->toBeInstanceOf(PhodParseFailedException::class);
+        expect($result->exception->issue)->toBeInstanceOf(PhodParseIssue::class);
+        expect($result->exception->issue->message)->toBe('名前 must be string');
+    });
 });
 
 describe('optional method', function () {


### PR DESCRIPTION
- ParseContextクラスに新しい静的メソッド`extends`を追加し、親コンテキストと新しいパスを組み合わせて新しいコンテキストを生成できるようにしました。
- PhodSchemaクラスの`safeParse`メソッドを修正し、コンテキストを`null`で初期化するように変更しました。
- `safeParseWithContext`メソッドで、コンテキストが`null`の場合に新しいParseContextを生成するロジックを追加しました。
- AssociativeArraySchemaのテストを追加し、無効な値が渡された場合にエラーを返すことを確認しました。