### PR TITLE
feat: PhodParseFailedExceptionの移動とUnionSchemaの追加

### DIFF
--- a/src/Exception/PhodParseFailedException.php
+++ b/src/Exception/PhodParseFailedException.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Rei\Phod;
+namespace Rei\Phod\Exception;
+
+use Rei\Phod\PhodParseIssue;
 
 class PhodParseFailedException extends \Exception
 {

--- a/src/Exception/PhodUnionParseFailedException.php
+++ b/src/Exception/PhodUnionParseFailedException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Rei\Phod\Exception;
+
+use Rei\Phod\PhodParseIssue;
+use Rei\Phod\Exception\PhodParseFailedException;
+
+class PhodUnionParseFailedException extends PhodParseFailedException
+{
+    public function __construct(
+        readonly public array $unionErrors,
+        PhodParseIssue $issue,
+
+    ) {
+        parent::__construct($issue);
+    }
+
+}

--- a/src/ParseResult.php
+++ b/src/ParseResult.php
@@ -2,6 +2,8 @@
 
 namespace Rei\Phod;
 
+use Rei\Phod\Exception\PhodParseFailedException;
+
 /**
  * @template T
  */

--- a/src/Phod.php
+++ b/src/Phod.php
@@ -8,7 +8,7 @@ use Rei\Phod\Schema\AssociativeArraySchema;
 use Rei\Phod\Schema\FloatSchema;
 use Rei\Phod\Schema\StringSchema;
 use Rei\Phod\Message\MessageProvider;
-
+use Rei\Phod\Schema\UnionSchema;
 
 class Phod
 {
@@ -73,5 +73,16 @@ class Phod
     public function array(array $data = [], array $options = []): AssociativeArraySchema
     {
         return new AssociativeArraySchema($this->messageProvider, $data, $options);
+    }
+
+    /**
+     * Make a UnionSchema.
+     *
+     * @param PhodSchema[] $schemas
+     * @return UnionSchema
+     */
+    public function union(array $schemas): UnionSchema
+    {
+        return new UnionSchema($this->messageProvider, $schemas);
     }
 }

--- a/src/PhodSchema.php
+++ b/src/PhodSchema.php
@@ -4,7 +4,7 @@ namespace Rei\Phod;
 
 use Rei\Phod\ParseResult;
 use Rei\Phod\Message\MessageProvider;
-
+use Rei\Phod\Schema\UnionSchema;
 
 /**
  * @template T
@@ -188,5 +188,16 @@ class PhodSchema
     protected function cast(mixed $value): mixed
     {
         return $value;
+    }
+
+    /**
+     * or the schema
+     *
+     * @param PhodSchema $schema
+     * @return UnionSchema
+     */
+    public function or(PhodSchema $schema): UnionSchema
+    {
+        return new UnionSchema($this->messageProvider, [$this, $schema]);
     }
 }

--- a/src/Schema/ArraySchema.php
+++ b/src/Schema/ArraySchema.php
@@ -7,7 +7,7 @@ use Rei\Phod\ParseResult;
 use Rei\Phod\ParseContext;
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Message\MessageProvider;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 
 /**
  * @extends \Rei\Phod\PhodSchema<array>

--- a/src/Schema/AssociativeArraySchema.php
+++ b/src/Schema/AssociativeArraySchema.php
@@ -7,7 +7,7 @@ use Rei\Phod\ParseResult;
 use Rei\Phod\ParseContext;
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Message\MessageProvider;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 
 /**
  * @extends \Rei\Phod\PhodSchema<array>

--- a/src/Schema/BoolSchema.php
+++ b/src/Schema/BoolSchema.php
@@ -7,7 +7,7 @@ use Rei\Phod\ParseResult;
 use Rei\Phod\ParseContext;
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Message\MessageProvider;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 
 /**
  * @extends \Rei\Phod\PhodSchema<bool>

--- a/src/Schema/FloatSchema.php
+++ b/src/Schema/FloatSchema.php
@@ -7,7 +7,7 @@ use Rei\Phod\ParseResult;
 use Rei\Phod\ParseContext;
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Message\MessageProvider;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 
 /**
  * @extends \Rei\Phod\PhodSchema<float>

--- a/src/Schema/IntSchema.php
+++ b/src/Schema/IntSchema.php
@@ -7,7 +7,7 @@ use Rei\Phod\ParseResult;
 use Rei\Phod\ParseContext;
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Message\MessageProvider;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 
 /**
  * @extends \Rei\Phod\PhodSchema<int>

--- a/src/Schema/StringSchema.php
+++ b/src/Schema/StringSchema.php
@@ -7,7 +7,7 @@ use Rei\Phod\ParseResult;
 use Rei\Phod\ParseContext;
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Message\MessageProvider;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 
 /**
  * @extends \Rei\Phod\PhodSchema<string>

--- a/src/Schema/UnionSchema.php
+++ b/src/Schema/UnionSchema.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Rei\Phod\Schema;
+
+use Rei\Phod\PhodSchema;
+use Rei\Phod\ParseResult;
+use Rei\Phod\ParseContext;
+use Rei\Phod\PhodParseIssue;
+use Rei\Phod\Message\MessageProvider;
+use Rei\Phod\Exception\PhodParseFailedException;
+use Rei\Phod\Exception\PhodUnionParseFailedException;
+
+/**
+ * @extends \Rei\Phod\PhodSchema<mixed>
+ */
+class UnionSchema extends PhodSchema
+{
+    /**
+     * construct the schema
+     *
+     * @param MessageProvider $messageProvider
+     * @param PhodSchema[] $schemas
+     */
+    public function __construct(MessageProvider $messageProvider, array $schemas)
+    {
+        parent::__construct($messageProvider);
+        $this->isValidUnion($schemas);
+    }
+
+    /**
+     * Rule to check if the value matches any of the schemas.
+     *
+     * @param PhodSchema[] $schemas
+     * @return static
+     */
+    private function isValidUnion(array $schemas): static
+    {
+        $this->validators[] = function(mixed $value, ParseContext $context) use ($schemas) {
+            $errors = [];
+            foreach ($schemas as $schema) {
+                $result = $schema->safeParseWithContext($value, $context);
+                if ($result->success) {
+                    return $result;
+                }
+                $errors[] = $result->exception;
+            }
+
+            return new ParseResult(
+                false,
+                $value,
+                new PhodUnionParseFailedException(
+                    $errors,
+                    new PhodParseIssue(
+                        'invalid_type',
+                        $context->path,
+                        'Value must match one of the schemas',
+                    ),
+                ),
+            );
+        };
+
+        return $this;
+    }
+}

--- a/tests/Unit/PhodSchemaTest.php
+++ b/tests/Unit/PhodSchemaTest.php
@@ -5,7 +5,7 @@ use Rei\Phod\ParseResult;
 use Rei\Phod\ParseContext;
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Message\MessageProvider;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 
 beforeEach(function () {
     $this->messageProvider = new class implements MessageProvider {

--- a/tests/Unit/Schema/ArraySchemaTest.php
+++ b/tests/Unit/Schema/ArraySchemaTest.php
@@ -4,7 +4,7 @@ use Rei\Phod\ParseResult;
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Schema\ArraySchema;
 use Rei\Phod\Schema\StringSchema;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 
 
 describe('parse method', function () {

--- a/tests/Unit/Schema/AssociativeArraySchemaTest.php
+++ b/tests/Unit/Schema/AssociativeArraySchemaTest.php
@@ -3,7 +3,7 @@
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Schema\IntSchema;
 use Rei\Phod\Schema\StringSchema;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 use Rei\Phod\Schema\AssociativeArraySchema;
 
 describe('parse method', function () {

--- a/tests/Unit/Schema/BoolSchemaTest.php
+++ b/tests/Unit/Schema/BoolSchemaTest.php
@@ -2,7 +2,7 @@
 
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Schema\BoolSchema;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 
 describe('parse method', function () {
     it('should return the value if all validators return true', function () {

--- a/tests/Unit/Schema/FloatSchemaTest.php
+++ b/tests/Unit/Schema/FloatSchemaTest.php
@@ -2,7 +2,7 @@
 
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Schema\FloatSchema;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 
 
 describe('parse method', function () {

--- a/tests/Unit/Schema/IntSchemaTest.php
+++ b/tests/Unit/Schema/IntSchemaTest.php
@@ -2,7 +2,7 @@
 
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Schema\IntSchema;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 
 
 describe('parse method', function () {

--- a/tests/Unit/Schema/StringSchemaTest.php
+++ b/tests/Unit/Schema/StringSchemaTest.php
@@ -2,7 +2,7 @@
 
 use Rei\Phod\PhodParseIssue;
 use Rei\Phod\Schema\StringSchema;
-use Rei\Phod\PhodParseFailedException;
+use Rei\Phod\Exception\PhodParseFailedException;
 
 
 describe('parse method', function () {

--- a/tests/Unit/Schema/UnionSchemaTest.php
+++ b/tests/Unit/Schema/UnionSchemaTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Rei\Phod\Schema\IntSchema;
+use Rei\Phod\Schema\ArraySchema;
+use Rei\Phod\Schema\UnionSchema;
+use Rei\Phod\Schema\StringSchema;
+use Rei\Phod\Exception\PhodUnionParseFailedException;
+
+describe('UnionSchema', function () {
+    it('should return the value if it matches any schema', function () {
+        $schema = new UnionSchema($this->messageProvider, [
+            new StringSchema($this->messageProvider),
+            new IntSchema($this->messageProvider),
+        ]);
+
+        expect($schema->parse('value'))->toBe('value');
+        expect($schema->parse(123))->toBe('123');
+    });
+
+    it('should throw an exception if it does not match any schema', function () {
+        $schema = new UnionSchema($this->messageProvider, [
+            new ArraySchema($this->messageProvider, new StringSchema($this->messageProvider)),
+            new IntSchema($this->messageProvider),
+        ]);
+
+        expect(fn() => $schema->parse(1.23))->toThrow(PhodUnionParseFailedException::class, 'Value must match one of the schemas');
+    });
+
+    it('should throw an exception has children errors if it does not match any schema', function () {
+        $schema = new UnionSchema($this->messageProvider, [
+            new ArraySchema($this->messageProvider, new StringSchema($this->messageProvider)),
+            new IntSchema($this->messageProvider),
+        ]);
+
+        $result = $schema->safeParse(1.23);
+
+        $exception = $result->exception;
+        expect($exception)->toBeInstanceOf(PhodUnionParseFailedException::class);
+        /** @var PhodUnionParseFailedException $exception */
+        expect($exception->unionErrors)->toHaveLength(2);
+        expect($exception->unionErrors[0]->issue->message)->toBe('the value must be array');
+        expect($exception->unionErrors[1]->issue->message)->toBe('the value must be integer');
+    });
+});


### PR DESCRIPTION
- PhodParseFailedExceptionをsrc/Exceptionディレクトリに移動
- PhodクラスにUnionSchemaを作成するメソッドを追加
- PhodSchemaクラスにorメソッドを追加し、UnionSchemaを返す機能を実装
- 各SchemaクラスでPhodParseFailedExceptionのインポートを修正
- ParseResultクラスにPhodParseFailedExceptionをインポート
- コードの可読性向上のため、関連するuse文を整理